### PR TITLE
Add the missing dependency

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -81,7 +81,12 @@
             <artifactId>schema-registry-serde</artifactId>
             <version>1.1.5</version>
         </dependency>
-
+        <dependency>
+            <groupId>software.amazon.awssdk</groupId>
+            <artifactId>glue</artifactId>
+            <version>2.17.52</version>
+        </dependency>
+        
     </dependencies>
 
     <build>


### PR DESCRIPTION
*Issue #, [12](https://github.com/aws-samples/clickstream-producer-for-apache-kafka/issues/12)

*Description of changes:* Adding glue SDK will add the missing dependency which causes the error explain in the Issue # 12.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
