### PR TITLE
[Fix] - updated Maven repository to use HTTPS URL

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -11,7 +11,7 @@
     <repositories>
         <repository>
             <id>confluent</id>
-            <url>http://packages.confluent.io/maven/</url>
+            <url>https://packages.confluent.io/maven/</url>
         </repository>
     </repositories>
 


### PR DESCRIPTION
This issue occurs when executing `mvn clean package -f pom.xml`

```bash
[ERROR] Failed to execute goal on project KafkaClickstreamClient: Could not resolve dependencies for project com.amazonaws.kafka.samples:KafkaClickstreamClient:jar:1.0-SNAPSHOT: Failed to collect dependencies at io.confluent:kafka-avro-serializer:jar:5.2.1: Failed to read artifact descriptor for io.confluent:kafka-avro-serializer:jar:5.2.1: Could not transfer artifact io.confluent:kafka-avro-serializer:pom:5.2.1 from/to maven-default-http-blocker (http://0.0.0.0/): Blocked mirror for repositories: [confluent (http://packages.confluent.io/maven/, default, releases+snapshots)] -> [Help 1]
```

Updated Maven repository in `pom.xml` to use HTTPS URL


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
